### PR TITLE
Update MotoServer tests to use aws_region for bucket creation and resource map

### DIFF
--- a/aws_sam_testing/aws_sam.py
+++ b/aws_sam_testing/aws_sam.py
@@ -372,7 +372,7 @@ class AWSSAMToolkit(CloudFormationTool):
                             skip_pull_image=False,
                             log_file=str(log_file),
                             aws_region=os.environ.get("AWS_REGION", "eu-west-1"),
-                            aws_profile=os.environ.get("AWS_PROFILE", "default"),
+                            aws_profile=os.environ.get("AWS_PROFILE"),
                             warm_container_initialization_mode="EAGER",
                         )
 

--- a/tests/test_moto_server.py
+++ b/tests/test_moto_server.py
@@ -1,5 +1,5 @@
 class TestMotoServer:
-    def test_start_stop(self):
+    def test_start_stop(self, aws_region):
         import boto3
 
         from aws_sam_testing.moto_server import MotoServer
@@ -9,7 +9,10 @@ class TestMotoServer:
             moto_server.wait_for_start()
 
             s3 = boto3.client("s3", endpoint_url=f"http://127.0.0.1:{moto_server.port}")
-            s3.create_bucket(Bucket="test-bucket", CreateBucketConfiguration={"LocationConstraint": "eu-west-1"})
+            s3.create_bucket(
+                Bucket="test-bucket",
+                CreateBucketConfiguration={"LocationConstraint": aws_region},
+            )
             s3.put_object(Bucket="test-bucket", Key="test-key", Body=b"test-body")
             response = s3.get_object(Bucket="test-bucket", Key="test-key")
             assert response["Body"].read() == b"test-body"
@@ -17,7 +20,7 @@ class TestMotoServer:
             moto_server.stop()
             assert not moto_server.is_running
 
-    def test_moto_server_with_resource_map(self):
+    def test_moto_server_with_resource_map(self, aws_region):
         import boto3
         from moto.cloudformation.parsing import ResourceMap
 
@@ -42,7 +45,7 @@ Resources:
                 stack_name="test-stack",
                 parameters={},
                 tags={},
-                region_name="eu-west-1",
+                region_name=aws_region,
                 account_id="123456789012",
                 template=template,
                 cross_stack_resources={},

--- a/tests/test_moto_server.py
+++ b/tests/test_moto_server.py
@@ -9,10 +9,15 @@ class TestMotoServer:
             moto_server.wait_for_start()
 
             s3 = boto3.client("s3", endpoint_url=f"http://127.0.0.1:{moto_server.port}")
-            s3.create_bucket(
-                Bucket="test-bucket",
-                CreateBucketConfiguration={"LocationConstraint": aws_region},
-            )
+            if aws_region == "us-east-1":
+                s3.create_bucket(
+                    Bucket="test-bucket",
+                )
+            else:
+                s3.create_bucket(
+                    Bucket="test-bucket",
+                    CreateBucketConfiguration={"LocationConstraint": aws_region},
+                )
             s3.put_object(Bucket="test-bucket", Key="test-key", Body=b"test-body")
             response = s3.get_object(Bucket="test-bucket", Key="test-key")
             assert response["Body"].read() == b"test-body"


### PR DESCRIPTION
…ource map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced test coverage by allowing tests to run with different AWS regions, improving flexibility and accuracy when simulating S3 bucket creation and resource mapping across regions.
- **Chores**
  - Updated local API invocation to respect the absence of an AWS profile environment variable without defaulting to "default".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->